### PR TITLE
Update Source.html to introduce Rüsh Release

### DIFF
--- a/Application/View/En/Source.xyl
+++ b/Application/View/En/Source.xyl
@@ -192,10 +192,10 @@ var_dump(HOA); // bool(true)</code></pre>
     <p>The <strong>master compatibility number</strong> (MCN) represents the
     number of time where the backward compatibility could not be ensured, in
     other words where it is not possible to apply an update without any risk (we
-    also speak about backward compatibility break, BC). Before a library to
-    reach the finalized state, its MCN is set to 0. Next, it is set to 1, then
-    it increases when needed. For instance, the snapshot of the day could be
-    <code>1.<value formatter="date" formatter-format="y.m.d" /></code>.</p>
+    also speak about backward compatibility break, BC break). Before a library
+    to reach the finalized state, its MCN is set to 0. Next, it is set to 1,
+    then it increases when needed. For instance, the snapshot of the day could
+    be <code>1.<value formatter="date" formatter-format="y.m.d" /></code>.</p>
     <p>Thus, to use the latest snapshot of the <code>Hoa\Websocket</code>
     library, you will have to write in your <code>composer.json</code> file:</p>
     <pre><code class="language-json">{

--- a/Application/View/Fr/Source.xyl
+++ b/Application/View/Fr/Source.xyl
@@ -230,7 +230,7 @@ var_dump(HOA); // bool(true)</code></pre>
 }</code></pre>
     <p>L'<a href="https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-operator-">opérateur
     tilde</a>, ou opérateur de la prochaine <em lang="en">release</em>
-    significatve, dans Composer équivaut ici à <code>>=2.0,&amp;lt;3.0</code>,
+    significative, dans Composer équivaut ici à <code>>=2.0,&amp;lt;3.0</code>,
     soit la dernière version possible pour le même MCN.</p>
 
     <h3 id="PHP_versions" for="toc">Versions de PHP</h3>


### PR DESCRIPTION
To quickly view the modifications:

``` sh
$ cd Application/Public/
$ php -S 127.0.0.1:8888 -t . .webserver.php 2>&1 > /dev/null &
```

then, open http://127.0.0.1:8888/Fr/Source.html.

There is only the french version. When it will be validated, I will translate.
