### PR TITLE
Add PHPMetrics to “Who uses?”

### DIFF
--- a/Application/View/Shared/Welcome.xyl
+++ b/Application/View/Shared/Welcome.xyl
@@ -76,6 +76,12 @@
                  alt="DISC" />
           </a>
         </span>
+        <span class="image">
+          <a href="http://phpmetrics.org/" class="plain">
+            <img src="hoa://Application/Public/Image/Logo/PHPMetrics_little.png"
+                 alt="phpmetrics" />
+          </a>
+        </span>
       </p>
 
       <h2><_ with="Index">They support us!</_></h2>


### PR DESCRIPTION
I have created a specific logo since no one exists :-/.
Here is the final render:
![capture d ecran 2014-11-07 a 10 25 38](https://cloud.githubusercontent.com/assets/946104/4950821/346ad188-6660-11e4-81ba-a10d50a41a3d.png)
Are you ok?
Will fix https://github.com/hoaproject/W3/issues/9.

/cc @Halleck45
