### PR TITLE
Remove double-dot in blog post dates

### DIFF
--- a/Application/View/Shared/Welcome.xyl
+++ b/Application/View/Shared/Welcome.xyl
@@ -155,7 +155,7 @@
         <li bind="?blog">
           <a href="@blog_post:id=(?id)&amp;normalized_title=(?normalized_title)" bind="?title" />
           <small>(<time><value formatter="strftime"
-                               formatter-format="%b. '%y"
+                               formatter-format="%b '%y"
                                formatter-timestamp="(?posted)" /></time>)</small>
         </li>
       </ul>


### PR DESCRIPTION
`%b` adds a dot in some locales, for instance: November is “Nov” in English and “nov.” in French.