### PR TITLE
Documentation: Fallback to `README.md` when hack book chapter is missing

### DIFF
--- a/Application/.gitignore
+++ b/Application/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/composer.lock
+/Public/Static

--- a/Application/Bootstrap.php
+++ b/Application/Bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once 'vendor/autoload.php';

--- a/Application/Dispatcher/Kit.php
+++ b/Application/Dispatcher/Kit.php
@@ -9,23 +9,24 @@ use Hoa\Http;
 use Hoa\Promise;
 use Hoa\Xyl;
 
-class Kit extends Hoa\Dispatcher\Kit {
-
+class Kit extends Hoa\Dispatcher\Kit
+{
     public $promise = null;
     public $user    = null;
 
-    public function construct ( ) {
-
+    public function construct()
+    {
         parent::construct();
 
         $self          = $this;
         $this->user    = new Application\Model\User();
-        $this->promise = new Promise(function ( $fulfill ) use ( $self ) {
+        $this->promise = new Promise(function ($fulfill) use ($self) {
 
-            if(false === $self->router->isAsynchronous())
+            if (false === $self->router->isAsynchronous()) {
                 $main = 'hoa://Application/View/Shared/Main.xyl';
-            else
+            } else {
                 $main = 'hoa://Application/View/Shared/Main.fragment.xyl';
+            }
 
             $xyl = new Xyl(
                 new File\Read($main),

--- a/Application/Model/Awecode.php
+++ b/Application/Model/Awecode.php
@@ -4,8 +4,8 @@ namespace Application\Model;
 
 use Hoa\Database;
 
-class Awecode extends \Hoa\Model {
-
+class Awecode extends \Hoa\Model
+{
     public $_id;
     public $_title;
     public $_vimeoId;
@@ -13,13 +13,13 @@ class Awecode extends \Hoa\Model {
     public $_description_en;
     public $_description_fr;
 
-    public function construct ( ) {
-
+    public function construct()
+    {
         $this->setMappingLayer(Database\Dal::getLastInstance());
     }
 
-    public function open ( Array $constraints = array() ) {
-
+    public function open(array $constraints = [])
+    {
         $constraints = array_merge($this->getConstraints(), $constraints);
 
         $data = $this->getMappingLayer()
@@ -29,17 +29,18 @@ class Awecode extends \Hoa\Model {
                      ->execute($constraints)
                      ->fetchAll();
 
-        if(!isset($data[0]))
+        if (!isset($data[0])) {
             throw new Exception(
                 'Unknown awecode.', 0);
+        }
 
         $this->map($data[0]);
 
         return;
     }
 
-    public static function getAll ( ) {
-
+    public static function getAll()
+    {
         return Database\Dal::getLastInstance()
                    ->prepare(
                       'SELECT * FROM awecode'

--- a/Application/Model/Exception.php
+++ b/Application/Model/Exception.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace Application\Model {
+namespace Application\Model;
 
-class Exception extends \Hoa\Core\Exception { }
+use Hoa\Exception as HoaException;
 
+class Exception extends HoaException
+{
 }

--- a/Application/Model/User.php
+++ b/Application/Model/User.php
@@ -4,8 +4,8 @@ namespace Application\Model;
 
 use Hoa\Locale;
 
-class User {
-
+class User
+{
     protected $_locale           = null;
     protected static $_languages = [
         'en' => [
@@ -19,17 +19,16 @@ class User {
     ];
 
 
-    public function __construct ( ) {
-
+    public function __construct()
+    {
         $this->_locale = new Locale(new Locale\Localizer\Coerce('en'));
 
         return;
     }
 
-    public function guessLanguage ( $language ) {
-
-        if(true === $this->isValidLanguage($language)) {
-
+    public function guessLanguage($language)
+    {
+        if (true === $this->isValidLanguage($language)) {
             $this->_locale->setLocalizer(
                 new Locale\Localizer\Coerce($language)
             );
@@ -41,14 +40,12 @@ class User {
         $language = null;
 
         try {
-
             $this->_locale->setLocalizer(new Locale\Localizer\Http());
             $language = $this->_locale->getLanguage();
+        } catch (Locale\Exception $e) {
         }
-        catch ( Locale\Exception $e ) { }
 
-        if(false === $this->isValidLanguage($language)) {
-
+        if (false === $this->isValidLanguage($language)) {
             $language = 'en';
             $this->_locale->setLocalizer(new Locale\Localizer\Coerce($language));
         }
@@ -58,32 +55,33 @@ class User {
         return;
     }
 
-    public function isValidLanguage ( $language ) {
-
+    public function isValidLanguage($language)
+    {
         return true === array_key_exists($language, static::$_languages);
     }
 
-    public function getLocale ( ) {
-
+    public function getLocale()
+    {
         return $this->_locale;
     }
 
-    public function getLanguageName ( ) {
-
+    public function getLanguageName()
+    {
         return static::$_languages[$this->_locale->getLanguage()]['name'];
     }
 
-    public function getRegions ( ) {
-
+    public function getRegions()
+    {
         return static::$_languages[$this->_locale->getLanguage()]['regions'];
     }
 
-    public function getAvailableLanguages ( ) {
-
+    public function getAvailableLanguages()
+    {
         $out = [];
 
-        foreach(static::$_languages as $short => $details)
+        foreach (static::$_languages as $short => $details) {
             $out[$short] = $details['name'];
+        }
 
         return $out;
     }

--- a/Application/Public/.webserver.php
+++ b/Application/Public/.webserver.php
@@ -1,8 +1,6 @@
 <?php
 
-require_once dirname(dirname(__DIR__)) .
-             DIRECTORY_SEPARATOR . 'Data' .
-             DIRECTORY_SEPARATOR . 'Core.link.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Bootstrap.php';
 
 use Hoa\Router;
 use Hoa\Dispatcher;

--- a/Application/Public/index.php
+++ b/Application/Public/index.php
@@ -1,8 +1,6 @@
 <?php
 
-require_once dirname(dirname(__DIR__)) .
-             DIRECTORY_SEPARATOR . 'Data' .
-             DIRECTORY_SEPARATOR . 'Core.link.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Bootstrap.php';
 
 use Hoa\Consistency;
 use Hoa\Dispatcher;

--- a/Application/Public/index.php
+++ b/Application/Public/index.php
@@ -4,8 +4,8 @@ require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'Bootstrap.php';
 
 use Hoa\Consistency;
 use Hoa\Dispatcher;
-use Hoa\Router;
 use Hoa\Protocol;
+use Hoa\Router;
 
 $autoloader = new Consistency\Autoloader();
 $autoloader->addNamespace('Application', dirname(__DIR__));

--- a/Application/Resource/Error.php
+++ b/Application/Resource/Error.php
@@ -10,13 +10,12 @@ class Error extends Resource
     public function get(Kit $_this, $exception)
     {
         switch (get_class($exception)) {
-
             case 'Hoa\Router\Exception\NotFound':
                 $_this->view->getOutputStream()->sendStatus(
                     Http\Response::STATUS_NOT_FOUND
                 );
 
-              break;
+                break;
 
             default:
                 $_this->view->getOutputStream()->sendStatus(
@@ -31,8 +30,7 @@ class Error extends Resource
             ->then(curry([$this, 'doMainOverlay'], …, 'Error'))
             ->then([$this, 'doComment'])
             ->then([$this, 'doFooter'])
-            ->then([$this, 'doRender'])
-            ;
+            ->then([$this, 'doRender']);
 
         return;
     }

--- a/Application/Resource/Error.php
+++ b/Application/Resource/Error.php
@@ -2,20 +2,20 @@
 
 namespace Application\Resource;
 
-use Hoa\Router;
-use Hoa\Http;
 use Application\Dispatcher\Kit;
+use Hoa\Http;
 
-class Error extends Resource {
-
-    public function get ( Kit $_this, $exception ) {
-
-        switch(get_class($exception)) {
+class Error extends Resource
+{
+    public function get(Kit $_this, $exception)
+    {
+        switch (get_class($exception)) {
 
             case 'Hoa\Router\Exception\NotFound':
                 $_this->view->getOutputStream()->sendStatus(
                     Http\Response::STATUS_NOT_FOUND
                 );
+
               break;
 
             default:

--- a/Application/Resource/Fallback.php
+++ b/Application/Resource/Fallback.php
@@ -2,25 +2,22 @@
 
 namespace Application\Resource;
 
-use Hoa\Router;
-use Hoa\Http;
 use Application\Dispatcher\Kit;
+use Hoa\Http;
+use Hoa\Router;
 
-class Fallback {
-
-    public function get ( Kit $_this ) {
-
+class Fallback
+{
+    public function get(Kit $_this)
+    {
         $_this->router->removeRule('fallback');
         $router = $_this->router;
 
         require 'hoa://Application/Router.php';
 
         try {
-
             $_this->router->route();
-        }
-        catch ( Router\Exception\NotFound $e ) {
-
+        } catch (Router\Exception\NotFound $e) {
             $router->route('/Error.html');
             $rule                                       = &$router->getTheRule();
             $rule[$router::RULE_VARIABLES]['exception'] = $e;
@@ -32,8 +29,7 @@ class Fallback {
         $userAgent = Http\Runtime::getHeader('User-Agent');
         $response  = $_this->view->getOutputStream();
 
-        if(0 !== preg_match('#^Isso/#', $userAgent)) {
-
+        if (0 !== preg_match('#^Isso/#', $userAgent)) {
             $response->sendStatus($response::STATUS_OK);
 
             return;

--- a/Application/Resource/Generic.php
+++ b/Application/Resource/Generic.php
@@ -2,11 +2,11 @@
 
 namespace Application\Resource;
 
-use Hoa\Promise;
 use Application\Dispatcher\Kit;
+use Hoa\Promise;
 
-class Generic extends Resource {
-
+class Generic extends Resource
+{
     protected $_metaData = [
         'source'      => ['translation' => 'Source'],
         'literature'  => ['translation' => 'Literature'],
@@ -20,44 +20,47 @@ class Generic extends Resource {
 
 
 
-    public function get ( Kit $_this ) {
-
+    public function get(Kit $_this)
+    {
         $metaData = $this->_metaData;
         $theRule  = $_this->router->getTheRule();
         $router   = $_this->router;
         $file     = $theRule[$router::RULE_VARIABLES]['_uri'];
 
-        if('.html' === substr($file, -5, 5))
+        if ('.html' === substr($file, -5, 5)) {
             $file = substr($file, 0, strlen($file) - 5);
+        }
 
         $_this
             ->promise
-            ->then(function ( Kit $kit ) use ( &$file, $theRule ) {
+            ->then(function (Kit $kit) use (&$file, $theRule) {
 
                 $router = $kit->router;
 
-                if('home' === $theRule[$router::RULE_ID])
+                if ('home' === $theRule[$router::RULE_ID]) {
                     $file = 'Welcome';
+                }
 
                 return $kit;
             })
-            ->then(function ( Kit $kit ) use ( $metaData, $theRule ) {
+            ->then(function (Kit $kit) use ($metaData, $theRule) {
 
                 $router = $kit->router;
                 $ruleId = $theRule[$router::RULE_ID];
 
-                if(!isset($metaData[$ruleId]))
+                if (!isset($metaData[$ruleId])) {
                     return $kit;
+                }
 
                 $translationId = $metaData[$ruleId]['translation'];
 
-                $subPromise = new Promise(function ( $fulfill ) use ( $kit ) {
+                $subPromise = new Promise(function ($fulfill) use ($kit) {
 
                     $fulfill($kit);
                 });
                 $subPromise
                     ->then(curry([$this, 'doTranslation'], …, $translationId, $translationId))
-                    ->then(function ( Kit $kit ) use ( $translationId ) {
+                    ->then(function (Kit $kit) use ($translationId) {
 
                         return $this->doTitle(
                             $kit,

--- a/Application/Resource/Home.php
+++ b/Application/Resource/Home.php
@@ -2,17 +2,17 @@
 
 namespace Application\Resource;
 
-use Hoa\Promise;
 use Application\Dispatcher\Kit;
+use Hoa\Promise;
 
-class Home extends Resource {
-
-    public function get ( Kit $_this ) {
-
+class Home extends Resource
+{
+    public function get(Kit $_this)
+    {
         $_this
             ->promise
             ->then(curry([$this, 'doTranslation'], …, 'Index', 'Index'))
-            ->then(function ( Kit $kit ) {
+            ->then(function (Kit $kit) {
 
                 return $this->doTitle(
                     $kit,
@@ -21,13 +21,15 @@ class Home extends Resource {
                 );
             })
             ->then(curry([$this, 'doMainOverlay'], …, 'Welcome'))
-            ->then(function ( Kit $kit ) {
+            ->then(function (Kit $kit) {
 
                 $blogApi = $kit->router->unroute('blog') . 'api/posts?limit=5';
 
-                if(false !== $json = @file_get_contents($blogApi))
-                    if(null !== $handle = json_decode($json, true))
+                if (false !== $json = @file_get_contents($blogApi)) {
+                    if (null !== $handle = json_decode($json, true)) {
                         $kit->data->blog = $handle;
+                    }
+                }
 
                 return $kit;
             })

--- a/Application/Resource/Language.php
+++ b/Application/Resource/Language.php
@@ -2,20 +2,18 @@
 
 namespace Application\Resource;
 
-use Hoa\Locale;
-use Hoa\Router;
 use Application\Dispatcher\Kit;
+use Hoa\Router;
 
-class Language extends Resource {
-
-    public function get ( Kit $_this, $language, $uri ) {
-
+class Language extends Resource
+{
+    public function get(Kit $_this, $language, $uri)
+    {
         $language = strtolower($language);
         $_this->user->guessLanguage($language);
         $finalLanguage = $_this->user->getLocale()->getLanguage();
 
-        if($language !== $finalLanguage) {
-
+        if ($language !== $finalLanguage) {
             $response = $_this->view->getOutputStream();
             $response->sendStatus($response::STATUS_NOT_FOUND);
             $response->sendHeader(
@@ -44,15 +42,13 @@ class Language extends Resource {
 
         require 'hoa://Application/Router.php';
 
-        if(empty($uri))
+        if (empty($uri)) {
             $uri = '/';
+        }
 
         try {
-
             $_this->router->route($uri);
-        }
-        catch ( Router\Exception\NotFound $e ) {
-
+        } catch (Router\Exception\NotFound $e) {
             $router->route('/Error.html');
             $rule                                       = &$router->getTheRule();
             $rule[$router::RULE_VARIABLES]['exception'] = $e;
@@ -63,7 +59,7 @@ class Language extends Resource {
 
         $_this->router->setPrefix('/' . ucfirst($language));
 
-        $theRule = &$_this->router->getTheRule();
+        $theRule                                  = &$_this->router->getTheRule();
         $theRule[Router::RULE_VARIABLES]['_this'] = $_this;
 
         $_this->promise = $_this->promise->then(

--- a/Application/Resource/Literature/Contributor.php
+++ b/Application/Resource/Literature/Contributor.php
@@ -2,25 +2,25 @@
 
 namespace Application\Resource\Literature;
 
-use Hoa\Promise;
 use Application\Dispatcher\Kit;
 use Application\Resource;
+use Hoa\Promise;
 
-class Contributor extends Resource {
-
-    public function get ( Kit $_this ) {
-
+class Contributor extends Resource
+{
+    public function get(Kit $_this)
+    {
         $_this
             ->promise
-            ->then(function ( Kit $kit ) {
+            ->then(function (Kit $kit) {
 
-                $subPromise = new Promise(function ( $fulfill ) use ( $kit ) {
+                $subPromise = new Promise(function ($fulfill) use ($kit) {
 
                     $fulfill($kit);
                 });
                 $subPromise
                     ->then(curry([$this, 'doTranslation'], …, 'Literature', 'Literature'))
-                    ->then(function ( Kit $kit ) {
+                    ->then(function (Kit $kit) {
 
                         return $this->doTitle(
                             $kit,
@@ -33,7 +33,7 @@ class Contributor extends Resource {
 
                 return $subPromise;
             })
-            ->then(function ( Kit $kit ) {
+            ->then(function (Kit $kit) {
 
                 $language = ucfirst($kit->user->getLocale()->getLanguage());
 

--- a/Application/Resource/Literature/Hack.php
+++ b/Application/Resource/Literature/Hack.php
@@ -2,25 +2,25 @@
 
 namespace Application\Resource\Literature;
 
-use Hoa\Promise;
 use Application\Dispatcher\Kit;
 use Application\Resource;
+use Hoa\Promise;
 
-class Hack extends Resource {
-
-    public function get ( Kit $_this, $chapter ) {
-
+class Hack extends Resource
+{
+    public function get(Kit $_this, $chapter)
+    {
         $_this
             ->promise
-            ->then(function ( Kit $kit ) use ( $chapter ) {
+            ->then(function (Kit $kit) use ($chapter) {
 
-                $subPromise = new Promise(function ( $fulfill ) use ( $kit ) {
+                $subPromise = new Promise(function ($fulfill) use ($kit) {
 
                     $fulfill($kit);
                 });
                 $subPromise
                     ->then(curry([$this, 'doTranslation'], …, 'Literature', 'Literature'))
-                    ->then(function ( Kit $kit ) use ( $chapter ) {
+                    ->then(function (Kit $kit) use ($chapter) {
 
                         return $this->doTitle(
                             $kit,
@@ -33,7 +33,7 @@ class Hack extends Resource {
                 return $subPromise;
             })
             ->then(curry([$this, 'doMainOverlay'], …, 'Literature/Hack'))
-            ->then(function ( Kit $kit ) use ( $chapter ) {
+            ->then(function (Kit $kit) use ($chapter) {
 
                 $chapter  = ucfirst($chapter);
                 $language = ucfirst($kit->user->getLocale()->getLanguage());

--- a/Application/Resource/Literature/Hack.php
+++ b/Application/Resource/Literature/Hack.php
@@ -46,7 +46,7 @@ class Hack extends Resource
                     throw new Router\Exception\NotFound('Library does not exist.');
                 }
 
-                if (false === file_exists($hackChapter)) {
+                if (false === file_exists($hackIndex)) {
                     if (false === file_exists($readme)) {
                         throw new Router\Exception\NotFound(
                             'This library has no documentation yet.'
@@ -73,12 +73,6 @@ class Hack extends Resource
                     $kit->view->addOverlay('hoa://Application/View/Shared/Literature/Hack/Readme.xyl');
                     $kit->data->readme = $readmeCompiled;
                 } else {
-                    if (false === file_exists($hackIndex)) {
-                        throw new Router\Exception\NotFound(
-                            'Hack book chapter does not exist in this language.'
-                        );
-                    }
-
                     $kit->view->addOverlay($hackIndex);
                 }
 

--- a/Application/Resource/Literature/Hack.php
+++ b/Application/Resource/Literature/Hack.php
@@ -5,6 +5,8 @@ namespace Application\Resource\Literature;
 use Application\Dispatcher\Kit;
 use Application\Resource;
 use Hoa\Promise;
+use Hoa\Router;
+use League\CommonMark\CommonMarkConverter;
 
 class Hack extends Resource
 {
@@ -13,15 +15,12 @@ class Hack extends Resource
         $_this
             ->promise
             ->then(function (Kit $kit) use ($chapter) {
-
                 $subPromise = new Promise(function ($fulfill) use ($kit) {
-
                     $fulfill($kit);
                 });
                 $subPromise
                     ->then(curry([$this, 'doTranslation'], …, 'Literature', 'Literature'))
                     ->then(function (Kit $kit) use ($chapter) {
-
                         return $this->doTitle(
                             $kit,
                             'Hoa\\' . ucfirst($chapter) .
@@ -34,15 +33,54 @@ class Hack extends Resource
             })
             ->then(curry([$this, 'doMainOverlay'], …, 'Literature/Hack'))
             ->then(function (Kit $kit) use ($chapter) {
-
                 $chapter  = ucfirst($chapter);
                 $language = ucfirst($kit->user->getLocale()->getLanguage());
 
                 $kit->data->chapter = $chapter;
-                $kit->view->addOverlay(
-                    'hoa://Library/' . $chapter .
-                    '/Documentation/' . $language . '/Index.xyl'
-                );
+                $root               = '/usr/local/lib/Hoa/' . $chapter . '/';
+                $hackChapter        = $root . 'Documentation/';
+                $hackIndex          = $hackChapter . $language . '/Index.xyl';
+                $readme             = $root . 'README.md';
+
+                if (false === file_exists($root)) {
+                    throw new Router\Exception\NotFound('Library does not exist.');
+                }
+
+                if (false === file_exists($hackChapter)) {
+                    if (false === file_exists($readme)) {
+                        throw new Router\Exception\NotFound(
+                            'This library has no documentation yet.'
+                        );
+                    }
+
+                    $readmeContent = file_get_contents($readme);
+                    $readmeContent = preg_replace(
+                        [
+                            // Remove introduction but keep the abstract.
+                            '/^.*# Hoa[^\n]+\n+/s',
+                            // Remove Installation Section.
+                            '/## Installation.*(?=## Quick usage)/s',
+                            // Remove Documentation and next sections.
+                            '/\n+## Documentation.*$/s'
+                        ],
+                        '',
+                        $readmeContent
+                    );
+
+                    $converter      = new CommonMarkConverter();
+                    $readmeCompiled = $converter->convertToHtml($readmeContent);
+
+                    $kit->view->addOverlay('hoa://Application/View/Shared/Literature/Hack/Readme.xyl');
+                    $kit->data->readme = $readmeCompiled;
+                } else {
+                    if (false === file_exists($hackIndex)) {
+                        throw new Router\Exception\NotFound(
+                            'Hack book chapter does not exist in this language.'
+                        );
+                    }
+
+                    $kit->view->addOverlay($hackIndex);
+                }
 
                 return $kit;
             })

--- a/Application/Resource/Literature/Learn.php
+++ b/Application/Resource/Literature/Learn.php
@@ -5,14 +5,14 @@ namespace Application\Resource\Literature;
 use Application\Dispatcher\Kit;
 use Application\Resource;
 
-class Learn extends Resource {
-
-    public function get ( Kit $_this, $chapter ) {
-
+class Learn extends Resource
+{
+    public function get(Kit $_this, $chapter)
+    {
         $_this
             ->promise
             ->then(curry([$this, 'doTitle'], …, 'Manuel d\'apprentissage'))
-            ->then(function ( Kit $kit ) use ( $chapter ) {
+            ->then(function (Kit $kit) use ($chapter) {
 
                 $chapter = ucfirst($chapter);
 

--- a/Application/Resource/Literature/Minitutorial.php
+++ b/Application/Resource/Literature/Minitutorial.php
@@ -5,14 +5,14 @@ namespace Application\Resource\Literature;
 use Application\Dispatcher\Kit;
 use Application\Resource;
 
-class Minitutorial extends Resource {
-
-    public function get ( Kit $_this ) {
-
+class Minitutorial extends Resource
+{
+    public function get(Kit $_this)
+    {
         $_this
             ->promise
             ->then(curry([$this, 'doTitle'], …, 'Mini-tutorial'))
-            ->then(function ( Kit $kit ) {
+            ->then(function (Kit $kit) {
 
                 $kit->view->addOverlay(
                     'hoa://Application/External/Literature/MiniTutorial/Index.xyl'

--- a/Application/Resource/Literature/Research.php
+++ b/Application/Resource/Literature/Research.php
@@ -6,21 +6,22 @@ use Application\Dispatcher\Kit;
 use Application\Resource;
 use Hoa\Router;
 
-class Research extends Resource {
-
-    public function get ( Kit $_this, $article ) {
-
+class Research extends Resource
+{
+    public function get(Kit $_this, $article)
+    {
         $_this
             ->promise
-            ->then(function ( Kit $kit ) use ( $article ) {
+            ->then(function (Kit $kit) use ($article) {
 
                 $article = ucfirst($article);
                 $file    = 'hoa://Application/External/Literature/Research/' .
                            $article . '.pdf';
 
-                if(false === file_exists($file))
+                if (false === file_exists($file)) {
                     throw new Router\Exception\NotFound(
                         'Article %s is not found', 0, $article);
+                }
 
                 $response = $kit->view->getOutputStream();
                 $response->sendHeader('Content-Type', 'application/pdf');

--- a/Application/Resource/Resource.php
+++ b/Application/Resource/Resource.php
@@ -6,16 +6,14 @@ use Application;
 use Application\Dispatcher\Kit;
 use Hoa\Consistency;
 use Hoa\File;
-use Hoa\Http;
-use Hoa\Promise;
 use Hoa\Router;
 use Hoa\Translate;
 use Hoa\Xyl;
 
-class Resource {
-
-    public function doTranslation ( Kit $kit, $translationFile, $translationId = null ) {
-
+class Resource
+{
+    public function doTranslation(Kit $kit, $translationFile, $translationId = null)
+    {
         $language = $kit->user->getLocale()->getLanguage();
 
         $kit->view->addTranslation(
@@ -34,29 +32,30 @@ class Resource {
         return $kit;
     }
 
-    public function doTitle ( Kit $kit, $title ) {
-
+    public function doTitle(Kit $kit, $title)
+    {
         $kit->data->title = $title;
 
         return $kit;
     }
 
-    public function doMainOverlay ( Kit $kit, $file ) {
-
+    public function doMainOverlay(Kit $kit, $file)
+    {
         $_file = 'hoa://Application/View/' .
                  ucfirst($kit->user->getLocale()->getLanguage()) .
                  '/' . $file . '.xyl';
 
-        if(false === file_exists($_file))
+        if (false === file_exists($_file)) {
             $_file = 'hoa://Application/View/Shared/' . $file . '.xyl';
+        }
 
         $kit->view->addOverlay($_file);
 
         return $kit;
     }
 
-    public function doComment ( Kit $kit ) {
-
+    public function doComment(Kit $kit)
+    {
         $router    = $kit->router;
         $theRule   = $router->getTheRule();
         $variables = $theRule[$router::RULE_VARIABLES];
@@ -66,21 +65,22 @@ class Resource {
         return $kit;
     }
 
-    public function doFooter ( Kit $kit ) {
-
+    public function doFooter(Kit $kit)
+    {
         $router    = $kit->router;
         $footer    = [];
         $theRule   = $router->getTheRule();
         $variables = $theRule[$router::RULE_VARIABLES];
 
-        foreach($variables as &$variable)
-            if(is_string($variable))
+        foreach ($variables as &$variable) {
+            if (is_string($variable)) {
                 $variable = ucfirst($variable);
+            }
+        }
 
         $oldPrefix = $router->getPrefix();
 
-        foreach($kit->user->getAvailableLanguages() as $short => $langName) {
-
+        foreach ($kit->user->getAvailableLanguages() as $short => $langName) {
             $router->setPrefix('/' . ucfirst($short));
             $footer[] = [
                 'link'     => $router->unroute(
@@ -99,18 +99,14 @@ class Resource {
         return $kit;
     }
 
-    public function doRender ( Kit $kit ) {
-
+    public function doRender(Kit $kit)
+    {
         $router = $kit->router;
 
-        if(false === $kit->router->isAsynchronous()) {
-
+        if (false === $kit->router->isAsynchronous()) {
             try {
-
                 $kit->view->render();
-            }
-            catch ( \Exception $e ) {
-
+            } catch (\Exception $e) {
                 $router->setPrefix('/');
                 $router->route('/Error.html');
                 $rule                                       = &$router->getTheRule();

--- a/Application/Resource/Video/Awecode.php
+++ b/Application/Resource/Video/Awecode.php
@@ -2,19 +2,19 @@
 
 namespace Application\Resource\Video;
 
-use Hoa\Promise;
 use Application\Dispatcher\Kit;
 use Application\Model;
 use Application\Resource;
+use Hoa\Promise;
 
-class Awecode extends Resource {
-
-    public function get ( Kit $_this, $id ) {
-
+class Awecode extends Resource
+{
+    public function get(Kit $_this, $id)
+    {
         $_this
             ->promise
             ->then(curry([$this, 'doTitle'], …, 'Awecode'))
-            ->then(function ( Kit $kit ) use ( $id ) {
+            ->then(function (Kit $kit) use ($id) {
 
                 Video::openDatabase();
                 $language = $kit->user->getLocale()->getLanguage();
@@ -30,10 +30,11 @@ class Awecode extends Resource {
                                                    ucfirst($awecode->id) .
                                                    '.srt';
 
-                if(false !== $pos = strpos($awecode->id, '-'))
+                if (false !== $pos = strpos($awecode->id, '-')) {
                     $libraryName = substr($awecode->id, 0, $pos);
-                else
+                } else {
                     $libraryName = $awecode->id;
+                }
 
                 $kit->data->awecode[0]->library = ucfirst($libraryName);
 

--- a/Application/Resource/Video/Video.php
+++ b/Application/Resource/Video/Video.php
@@ -2,22 +2,22 @@
 
 namespace Application\Resource\Video;
 
-use Hoa\Database;
-use Hoa\Promise;
 use Application\Dispatcher\Kit;
 use Application\Model;
 use Application\Resource;
+use Hoa\Database;
+use Hoa\Promise;
 
-class Video extends Resource {
-
-    public function get ( Kit $_this ) {
-
+class Video extends Resource
+{
+    public function get(Kit $_this)
+    {
         $self = $this;
 
         $_this
             ->promise
             ->then(curry([$this, 'doTranslation'], …, 'Video', 'Video'))
-            ->then(function ( Kit $kit ) {
+            ->then(function (Kit $kit) {
 
                 return $this->doTitle(
                     $kit,
@@ -25,14 +25,13 @@ class Video extends Resource {
                               ->_('Videos')
                 );
             })
-            ->then(function ( Kit $kit ) use ( $self ) {
+            ->then(function (Kit $kit) use ($self) {
 
                 $self->openDatabase();
                 $language = $kit->user->getLocale()->getLanguage();
                 $awecodes = Model\Awecode::getAll();
 
-                foreach($awecodes as &$awecode) {
-
+                foreach ($awecodes as &$awecode) {
                     $awecode['id']          = ucfirst($awecode['id']);
                     $awecode['description'] = $awecode['description_' . $language];
                 }
@@ -49,8 +48,8 @@ class Video extends Resource {
         return;
     }
 
-    public static function openDatabase ( ) {
-
+    public static function openDatabase()
+    {
         Database\Dal::initializeParameters([
             'connection.list.awecode.dal' => Database\Dal::PDO,
             'connection.list.awecode.dsn' => 'sqlite:hoa://Data/Variable/Database/Awecode.sqlite'

--- a/Application/View/En/Literature.xyl
+++ b/Application/View/En/Literature.xyl
@@ -16,47 +16,47 @@
     about all the libraries of Hoa. Chapters are unordered. No library will have
     a secret for you and you will be able to <strong>hack</strong> them!</p>
     <ul class="columns" data-columns="4">
-      <li><code>Acl</code></li>
+      <li><a href="@hack:chapter=Acl"><em><code>Acl</code></em></a></li>
       <li><a href="@hack:chapter=Bench"><code>Bench</code></a></li>
       <li><code>Cache</code></li>
-      <li><code>Cli</code></li>
+      <li><a href="@hack:chapter=Cli"><em><code>Cli</code></em></a></li>
       <li><a href="@hack:chapter=Compiler"><code>Compiler</code></a></li>
-      <li><code>Consistency</code></li>
+      <li><a href="@hack:chapter=Consistency"><em><code>Consistency</code></em></a></li>
       <li><a href="@hack:chapter=Console"><code>Console</code></a></li>
       <li><code>Database</code></li>
-      <li><code>Devtools</code></li>
+      <li><a href="@hack:chapter=Devtools"><em><code>Devtools</code></em></a></li>
       <li><code>Dispatcher</code></li>
       <li><a href="@hack:chapter=Dns"><code>Dns</code></a></li>
-      <li><code>Event</code></li>
+      <li><a href="@hack:chapter=Event"><em><code>Event</code></em></a></li>
       <li><a href="@hack:chapter=Eventsource"><code>Eventsource</code></a></li>
-      <li><code>Exception</code></li>
+      <li><a href="@hack:chapter=Exception"><em><code>Exception</code></em></a></li>
       <li><a href="@hack:chapter=Fastcgi"><code>Fastcgi</code></a></li>
       <li><code>File</code></li>
-      <li><code>Graph</code></li>
+      <li><a href="@hack:chapter=Graph"><em><code>Graph</code></em></a></li>
       <li><code>Http</code></li>
-      <li><code>Irc</code></li>
-      <li><code>Iterator</code></li>
-      <li><code>Json</code></li>
-      <li><code>Locale</code></li>
+      <li><a href="@hack:chapter=Irc"><em><code>Irc</code></em></a></li>
+      <li><a href="@hack:chapter=Iterator"><em><code>Iterator</code></em></a></li>
+      <li><a href="@hack:chapter=Json"><em><code>Json</code></em></a></li>
+      <li><a href="@hack:chapter=Locale"><em><code>Locale</code></em></a></li>
       <li><code>Log</code></li>
-      <li><code>Mail</code></li>
-      <li><code>Math</code></li>
+      <li><a href="@hack:chapter=Mail"><em><code>Mail</code></em></a></li>
+      <li><a href="@hack:chapter=Math"><em><code>Math</code></em></a></li>
       <li><code>Memory</code></li>
       <li><a href="@hack:chapter=Mime"><code>Mime</code></a></li>
       <li><code>Model</code></li>
       <li><code>Notification</code></li>
-      <li><code>Praspel</code></li>
+      <li><a href="@hack:chapter=Praspel"><em><code>Praspel</code></em></a></li>
       <li><code>Promise</code></li>
-      <li><code>Protocol</code></li>
+      <li><a href="@hack:chapter=Protocol"><em><code>Protocol</code></em></a></li>
       <li><code>Prototype</code></li>
       <li><code>Realdom</code></li>
-      <li><code>Regex</code></li>
+      <li><a href="@hack:chapter=Regex"><em><code>Regex</code></em></a></li>
       <li><a href="@hack:chapter=Registry"><code>Registry</code></a></li>
       <li><a href="@hack:chapter=Router"><code>Router</code></a></li>
       <li><a href="@hack:chapter=Ruler"><code>Ruler</code></a></li>
       <li><code>Serialize</code></li>
-      <li><code>Session</code></li>
-      <li><code>Socket</code></li>
+      <li><a href="@hack:chapter=Session"><em><code>Session</code></em></a></li>
+      <li><a href="@hack:chapter=Socket"><em><code>Socket</code></em></a></li>
       <li><code>Stream</code></li>
       <li><code>Stringbuffer</code></li>
       <li><a href="@hack:chapter=Test"><code>Test</code></a></li>
@@ -64,7 +64,7 @@
       <li><code>Tree</code></li>
       <li><a href="@hack:chapter=Ustring"><code>Ustring</code></a></li>
       <li><a href="@hack:chapter=View"><code>View</code></a></li>
-      <li><code>Visitor</code></li>
+      <li><a href="@hack:chapter=Visitor"><em><code>Visitor</code></em></a></li>
       <li><a href="@hack:chapter=Websocket"><code>Websocket</code></a></li>
       <li><a href="@hack:chapter=Worker"><code>Worker</code></a></li>
       <li><code>Xml</code></li>

--- a/Application/View/Fr/Literature.xyl
+++ b/Application/View/Fr/Literature.xyl
@@ -18,47 +18,47 @@
     chapitres sont non-ordonnées. Toutes les bibliothèques n'auront plus aucun
     secret pour vous et ainsi vous pourrez les <strong>bidouiller</strong> !</p>
     <ul class="columns" data-columns="4">
-      <li><code>Acl</code></li>
+      <li><a href="@hack:chapter=Acl"><em><code>Acl</code></em></a></li>
       <li><a href="@hack:chapter=Bench"><code>Bench</code></a></li>
       <li><code>Cache</code></li>
-      <li><code>Cli</code></li>
+      <li><a href="@hack:chapter=Cli"><em><code>Cli</code></em></a></li>
       <li><a href="@hack:chapter=Compiler"><code>Compiler</code></a></li>
-      <li><code>Consistency</code></li>
+      <li><a href="@hack:chapter=Consistency"><em><code>Consistency</code></em></a></li>
       <li><a href="@hack:chapter=Console"><code>Console</code></a></li>
       <li><code>Database</code></li>
-      <li><code>Devtools</code></li>
+      <li><a href="@hack:chapter=Devtools"><em><code>Devtools</code></em></a></li>
       <li><code>Dispatcher</code></li>
       <li><a href="@hack:chapter=Dns"><code>Dns</code></a></li>
-      <li><code>Event</code></li>
+      <li><a href="@hack:chapter=Event"><em><code>Event</code></em></a></li>
       <li><a href="@hack:chapter=Eventsource"><code>Eventsource</code></a></li>
-      <li><code>Exception</code></li>
+      <li><a href="@hack:chapter=Exception"><em><code>Exception</code></em></a></li>
       <li><a href="@hack:chapter=Fastcgi"><code>Fastcgi</code></a></li>
       <li><code>File</code></li>
-      <li><code>Graph</code></li>
+      <li><a href="@hack:chapter=Graph"><em><code>Graph</code></em></a></li>
       <li><code>Http</code></li>
-      <li><code>Irc</code></li>
-      <li><code>Iterator</code></li>
-      <li><code>Json</code></li>
-      <li><code>Locale</code></li>
+      <li><a href="@hack:chapter=Irc"><em><code>Irc</code></em></a></li>
+      <li><a href="@hack:chapter=Iterator"><em><code>Iterator</code></em></a></li>
+      <li><a href="@hack:chapter=Json"><em><code>Json</code></em></a></li>
+      <li><a href="@hack:chapter=Locale"><em><code>Locale</code></em></a></li>
       <li><code>Log</code></li>
-      <li><code>Mail</code></li>
-      <li><code>Math</code></li>
+      <li><a href="@hack:chapter=Mail"><em><code>Mail</code></em></a></li>
+      <li><a href="@hack:chapter=Math"><em><code>Math</code></em></a></li>
       <li><code>Memory</code></li>
       <li><a href="@hack:chapter=Mime"><code>Mime</code></a></li>
       <li><code>Model</code></li>
       <li><code>Notification</code></li>
-      <li><code>Praspel</code></li>
+      <li><a href="@hack:chapter=Praspel"><em><code>Praspel</code></em></a></li>
       <li><code>Promise</code></li>
-      <li><code>Protocol</code></li>
+      <li><a href="@hack:chapter=Protocol"><em><code>Protocol</code></em></a></li>
       <li><code>Prototype</code></li>
       <li><code>Realdom</code></li>
-      <li><code>Regex</code></li>
+      <li><a href="@hack:chapter=Regex"><em><code>Regex</code></em></a></li>
       <li><a href="@hack:chapter=Registry"><code>Registry</code></a></li>
       <li><a href="@hack:chapter=Router"><code>Router</code></a></li>
       <li><a href="@hack:chapter=Ruler"><code>Ruler</code></a></li>
       <li><code>Serialize</code></li>
-      <li><code>Session</code></li>
-      <li><code>Socket</code></li>
+      <li><a href="@hack:chapter=Session"><em><code>Session</code></em></a></li>
+      <li><a href="@hack:chapter=Socket"><em><code>Socket</code></em></a></li>
       <li><code>Stream</code></li>
       <li><code>Stringbuffer</code></li>
       <li><a href="@hack:chapter=Test"><code>Test</code></a></li>
@@ -66,7 +66,7 @@
       <li><code>Tree</code></li>
       <li><a href="@hack:chapter=Ustring"><code>Ustring</code></a></li>
       <li><a href="@hack:chapter=View"><code>View</code></a></li>
-      <li><code>Visitor</code></li>
+      <li><a href="@hack:chapter=Visitor"><em><code>Visitor</code></em></a></li>
       <li><a href="@hack:chapter=Websocket"><code>Websocket</code></a></li>
       <li><a href="@hack:chapter=Worker"><code>Worker</code></a></li>
       <li><code>Xml</code></li>

--- a/Application/View/Shared/Literature/Hack/Readme.xyl
+++ b/Application/View/Shared/Literature/Hack/Readme.xyl
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<overlay xmlns="http://hoa-project.net/xyl/xylophone">
+  <yield id="chapter">
+    <p class="warning">Unfortunately, the documentation of this library has not
+    been written yet. However, the <code>README.md</code> file may contain
+    enough information to help you. This document is an extract of the
+    <code>README.md</code> file.<br />
+    Sorry for this inconvenience. Be ensured we are working hard to fix
+    this.</p>
+
+    <value bind="?readme" />
+  </yield>
+</overlay>

--- a/Application/View/Shared/Welcome.xyl
+++ b/Application/View/Shared/Welcome.xyl
@@ -8,47 +8,47 @@
 
     <div class="tcenter" style="margin-top: 1em">
       <ul class="raw columns" data-columns="4">
-        <li><code>Acl</code></li>
+        <li><a href="@hack:chapter=Acl"><em><code>Acl</code></em></a></li>
         <li><a href="@hack:chapter=Bench"><code>Bench</code></a></li>
         <li><code>Cache</code></li>
-        <li><code>Cli</code></li>
+        <li><a href="@hack:chapter=Cli"><em><code>Cli</code></em></a></li>
         <li><a href="@hack:chapter=Compiler"><code>Compiler</code></a></li>
-        <li><code>Consistency</code></li>
+        <li><a href="@hack:chapter=Consistency"><em><code>Consistency</code></em></a></li>
         <li><a href="@hack:chapter=Console"><code>Console</code></a></li>
         <li><code>Database</code></li>
-        <li><code>Devtools</code></li>
+        <li><a href="@hack:chapter=Devtools"><em><code>Devtools</code></em></a></li>
         <li><code>Dispatcher</code></li>
         <li><a href="@hack:chapter=Dns"><code>Dns</code></a></li>
-        <li><code>Event</code></li>
+        <li><a href="@hack:chapter=Event"><em><code>Event</code></em></a></li>
         <li><a href="@hack:chapter=Eventsource"><code>Eventsource</code></a></li>
-        <li><code>Exception</code></li>
+        <li><a href="@hack:chapter=Exception"><em><code>Exception</code></em></a></li>
         <li><a href="@hack:chapter=Fastcgi"><code>Fastcgi</code></a></li>
         <li><code>File</code></li>
-        <li><code>Graph</code></li>
+        <li><a href="@hack:chapter=Graph"><em><code>Graph</code></em></a></li>
         <li><code>Http</code></li>
-        <li><code>Irc</code></li>
-        <li><code>Iterator</code></li>
-        <li><code>Json</code></li>
-        <li><code>Locale</code></li>
+        <li><a href="@hack:chapter=Irc"><em><code>Irc</code></em></a></li>
+        <li><a href="@hack:chapter=Iterator"><em><code>Iterator</code></em></a></li>
+        <li><a href="@hack:chapter=Json"><em><code>Json</code></em></a></li>
+        <li><a href="@hack:chapter=Locale"><em><code>Locale</code></em></a></li>
         <li><code>Log</code></li>
-        <li><code>Mail</code></li>
-        <li><code>Math</code></li>
+        <li><a href="@hack:chapter=Mail"><em><code>Mail</code></em></a></li>
+        <li><a href="@hack:chapter=Math"><em><code>Math</code></em></a></li>
         <li><code>Memory</code></li>
         <li><a href="@hack:chapter=Mime"><code>Mime</code></a></li>
         <li><code>Model</code></li>
         <li><code>Notification</code></li>
-        <li><code>Praspel</code></li>
+        <li><a href="@hack:chapter=Praspel"><em><code>Praspel</code></em></a></li>
         <li><code>Promise</code></li>
-        <li><code>Protocol</code></li>
+        <li><a href="@hack:chapter=Protocol"><em><code>Protocol</code></em></a></li>
         <li><code>Prototype</code></li>
         <li><code>Realdom</code></li>
-        <li><code>Regex</code></li>
+        <li><a href="@hack:chapter=Regex"><em><code>Regex</code></em></a></li>
         <li><a href="@hack:chapter=Registry"><code>Registry</code></a></li>
         <li><a href="@hack:chapter=Router"><code>Router</code></a></li>
         <li><a href="@hack:chapter=Ruler"><code>Ruler</code></a></li>
         <li><code>Serialize</code></li>
-        <li><code>Session</code></li>
-        <li><code>Socket</code></li>
+        <li><a href="@hack:chapter=Session"><em><code>Session</code></em></a></li>
+        <li><a href="@hack:chapter=Socket"><em><code>Socket</code></em></a></li>
         <li><code>Stream</code></li>
         <li><code>Stringbuffer</code></li>
         <li><a href="@hack:chapter=Test"><code>Test</code></a></li>
@@ -56,7 +56,7 @@
         <li><code>Tree</code></li>
         <li><a href="@hack:chapter=Ustring"><code>Ustring</code></a></li>
         <li><a href="@hack:chapter=View"><code>View</code></a></li>
-        <li><code>Visitor</code></li>
+        <li><a href="@hack:chapter=Visitor"><em><code>Visitor</code></em></a></li>
         <li><a href="@hack:chapter=Websocket"><code>Websocket</code></a></li>
         <li><a href="@hack:chapter=Worker"><code>Worker</code></a></li>
         <li><code>Xml</code></li>

--- a/Application/composer.json
+++ b/Application/composer.json
@@ -1,0 +1,18 @@
+{
+    "require": {
+        "hoa/consistency": "~1.0",
+        "hoa/database"   : "~0.0",
+        "hoa/dispatcher" : "~1.0",
+        "hoa/exception"  : "~1.0",
+        "hoa/file"       : "~1.0",
+        "hoa/http"       : "~1.0",
+        "hoa/locale"     : "~2.0",
+        "hoa/promise"    : "~0.0",
+        "hoa/protocol"   : "~1.0",
+        "hoa/router"     : "~3.0",
+        "hoa/translate"  : "~0.0",
+        "hoa/xyl"        : "~1.0",
+        "league/commonmark": "^0.13",
+        "hoa/mime": "~3.0"
+    }
+}


### PR DESCRIPTION
Address https://github.com/hoaproject/ActionBoard/issues/17.

Library list on the homepage, before:
<img width="846" alt="screen shot 2016-04-06 at 00 51 03" src="https://cloud.githubusercontent.com/assets/946104/14300604/c47346da-fb91-11e5-98ed-196f2c391a6f.png">

Library list on the homepage, after:
<img width="839" alt="screen shot 2016-04-06 at 00 51 15" src="https://cloud.githubusercontent.com/assets/946104/14300615/d518ee0e-fb91-11e5-9c5c-92fcc66c969f.png">

A hack book chapter showing the `README.md` extract:
<img width="707" alt="screen shot 2016-04-06 at 00 51 43" src="https://cloud.githubusercontent.com/assets/946104/14300621/e3841d06-fb91-11e5-9c9d-5eee4e47811f.png">

The only relevant commit is this one: https://github.com/hoaproject/W3/commit/f4bef7f17db0d5af599e32596771ca67bc1380fb.

Please @hoaproject/hoackers, give me your feedbacks :-).