### PR TITLE
Discourse Javascript served by our https proxy

### DIFF
--- a/Application/View/Shared/Overlay/Comment.xyl
+++ b/Application/View/Shared/Overlay/Comment.xyl
@@ -8,7 +8,7 @@
       url.shift();
 
       DiscourseEmbed = {
-          discourseUrl     : 'http://discourse.hoa-project.net/',
+          discourseUrl     : 'https://proxy-discourse.hoa-project.net/',
           discourseEmbedUrl: window.location.protocol + '//' + window.location.host + '/En/' + url.join('/')
       };
 


### PR DESCRIPTION
We had meet issue when turn Hoa website to HTTPS support, our discourse widget have not HTTPS, and the recent browser restrict access to theses dependencies.

We have set an proxy domain on our server with TLS support.